### PR TITLE
update regex to work with both bashate 0.3.1 and 0.3.2

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -21,7 +21,7 @@ class Bashate(Linter):
     cmd = 'bashate'
     comment_re = r'\s*#'
     regex = (
-        r'^(?P<error>[E])\d+: (?P<message>.+): '
+        r'^(\[[EW]\])? (?P<error>[E])\d+: (?P<message>.+): '
         r'\'(?P<near>.+)\'\n - (?P<file>.+) : L(?P<line>\d+)'
     )
     multiline = True


### PR DESCRIPTION
Optionally check for "[E] " or "[W] " at the beginning of the output so that the linter continues to work when 0.3.2 comes out.  Addresses #2.
