### PR TITLE
Don't stop matching on single quotes for near, fixes #10

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ class Bashate(Linter):
     comment_re = r'\s*#'
     regex = (
         r'^\[(?:(?P<error>E)|(?P<warning>W))\] E\d+: '
-        r'(?P<message>.+): \'(?P<near>.+)\'\n - '
+        r'(?P<message>.+): \'(?P<near>[^\']+)\'\n - '
         r'.+ : L(?P<line>\d+)'
     )
     multiline = True


### PR DESCRIPTION
Need to double check all tests but this enables marking E006 in `heredoc_ignore.sh`.
