### PR TITLE
catch end-of-file errors that have no near text to match, fixes #13

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -22,7 +22,7 @@ class Bashate(Linter):
     comment_re = r'\s*#'
     regex = (
         r'^\[(?:(?P<error>E)|(?P<warning>W))\] E\d+: '
-        r'(?P<message>.+): \'(?P<near>.+)\'\n - '
+        r'(?P<message>.+): \'(?P<near>.+)?\'\n - '
         r'.+ : L(?P<line>\d+)'
     )
     multiline = True


### PR DESCRIPTION
E012 and E040 don't output any text that would match P<near> so to at least match the errors it's optional.
