### PR TITLE
Support bashate 0.6.0

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -32,7 +32,6 @@ class Bashate(Linter):
         '--error=,': ''
     }
     tempfile_suffix = 'sh'
-    check_version = False
 
     def tmpfile(self, cmd, code, suffix=''):
         """

--- a/linter.py
+++ b/linter.py
@@ -20,11 +20,8 @@ class Bashate(Linter):
     cmd = 'bashate'
     comment_re = r'\s*#'
     regex = (
-        r'^\[(?:(?P<error>E)|(?P<warning>W))\] E\d+: '
-        r'(?P<message>.+): \'(?P<near>.+)?\'\n - '
-        r'.+ : L(?P<line>\d+)'
+        r'^.+:(?P<line>\d+):1: (?:(?P<error>E)|(?P<warning>W))\d{3} (?P<message>.+)'
     )
-    multiline = True
     defaults = {
         'selector': 'source.shell.bash',
         '--ignore=,': '',

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,6 @@ class Bashate(Linter):
     """Provides an interface to bashate."""
 
     cmd = 'bashate'
-    comment_re = r'\s*#'
     regex = (
         r'^.+:(?P<line>\d+):1: (?:(?P<error>E)|(?P<warning>W))\d{3} (?P<message>.+)'
     )

--- a/linter.py
+++ b/linter.py
@@ -18,6 +18,7 @@ class Bashate(Linter):
     """Provides an interface to bashate."""
 
     cmd = 'bashate'
+    comment_re = r'\s*#'
     regex = (
         r'^.+:(?P<line>\d+):1: (?:(?P<error>E)|(?P<warning>W))\d{3} (?P<message>.+)'
     )
@@ -28,6 +29,7 @@ class Bashate(Linter):
         '--error=,': ''
     }
     tempfile_suffix = 'sh'
+    check_version = False
 
     def tmpfile(self, cmd, code, suffix=''):
         """


### PR DESCRIPTION
As discovered in #19, the output style has changed with bashate 0.6.0 to follow pycodestyle (pep8) default output format, this should address the change pending some more testing.

As is, support for warnings breaks with this, see https://bugs.launchpad.net/bash8/+bug/1782960.